### PR TITLE
Fixed loading of log4j properties file

### DIFF
--- a/src/main/java/com/e3value/eval/ncf/ProfGenerator.java
+++ b/src/main/java/com/e3value/eval/ncf/ProfGenerator.java
@@ -146,7 +146,7 @@ public class ProfGenerator {
 
         Properties props = new Properties();
         try {
-            props.load(new FileInputStream("log4j.properties"));
+            props.load(ProfGenerator.class.getClassLoader().getResourceAsStream("log4j.properties"));
         } catch (FileNotFoundException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();


### PR DESCRIPTION
The file was being loaded through the fileInputStream. However, this file is defined as a Maven resource, so it should be loaded via the classLoader.
